### PR TITLE
[Fix : back] 메인페이지 id 전체 탐색 변경

### DIFF
--- a/backend/spring-boot-3/src/main/java/back/springbootdeveloper/seungchan/service/UserOfMainService.java
+++ b/backend/spring-boot-3/src/main/java/back/springbootdeveloper/seungchan/service/UserOfMainService.java
@@ -28,10 +28,11 @@ public class UserOfMainService {
     public List<YbUserInfomation> findAllByIsOb(boolean isOb) {
         List<YbUserInfomation> responseList = new ArrayList<>();
         List<UserInfo> users = userRepository.findAll();
-        for (int id = 1; id < users.size() + 1; id++) {
-            boolean isObUser = users.get(id - 1).isOb();
+
+        for (UserInfo user : users) {
+            boolean isObUser = user.isOb();
             if (isObUser == isOb) {
-                Long longId = (long) id;
+                Long longId = (long) user.getId();
                 UserUtill userUtill = userUtilRepository.findByUserId(longId);
                 AttendanceStatus attendanceStatus = attendanceStatusRepository.findByUserId(longId);
                 responseList.add(new YbUserInfomation(attendanceStatus, userUtill));


### PR DESCRIPTION
이전에는 없는 id까지 탐색을 하였다.
지금은 현재 유저들의 id을 이용하여 탐색
id 1, 2,3, 6 이런식으로 변경이 될때 문제 발생