### PR TITLE
[Fix : front] ype string trivially inferred from a string literal 수정

### DIFF
--- a/frontend/src/utils/constans/httpStatusEnum.ts
+++ b/frontend/src/utils/constans/httpStatusEnum.ts
@@ -1,5 +1,5 @@
 /**
  * Http Status 상수을 관리하는 enum
  */
-export const HTTP_STATUS_OK: string = 'OK';
-export const HTTP_BAD_REQUEST: string = 'BAD_REQUEST';
+export const HTTP_STATUS_OK = 'OK';
+export const HTTP_BAD_REQUEST = 'BAD_REQUEST';

--- a/frontend/src/utils/constans/modalTitle.ts
+++ b/frontend/src/utils/constans/modalTitle.ts
@@ -1,5 +1,5 @@
 /**
  * Modal Title 상수을 관리하는 파일
  */
-export const MODAL_TITLE_SUCCESS: string = '요청 성공';
-export const MODAL_TITLE_DANGER: string = '요청 실패';
+export const MODAL_TITLE_SUCCESS = '요청 성공';
+export const MODAL_TITLE_DANGER = '요청 실패';


### PR DESCRIPTION
TypeScript는 변수에 문자열 리터럴을 할당할 때 해당 변수의 타입을 자동으로 추론합니다. 따라서 명시적으로 타입 주석(: string)을 추가할 필요가 없습니다.